### PR TITLE
Feature/#8 if no directories are specified

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ $ giturl -o
 $ giturl
 ```
 
-
 ## Usecase
 
 The following is an example of opening a GitHub web page for the current directory:

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ If no directory is specified, the behavior is the same as when the current direc
 ```sh
 $ giturl -o .
 $ giturl .
-# are completely same as:
+#   These are completely same as:
 $ giturl -o
 $ giturl
 ```

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ $ giturl --open --app="Safari.app" .
 $ giturl --open --app="/Applications/any_browser_you_have.app" .
 ```
 
+If no directory is specified, the behavior is the same as when the current directory is specified.
+
+```sh
+$ giturl -o .
+$ giturl .
+# are completely same as:
+$ giturl -o
+$ giturl
+```
+
+
 ## Usecase
 
 The following is an example of opening a GitHub web page for the current directory:

--- a/giturl.gemspec
+++ b/giturl.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.authors       = ['Shinya Ohtani (shinyaohtani@github)']
   spec.email         = ['shinya_ohtani@yahoo.co.jp']
 
-  spec.homepage      = 'https://github.com/shinyaohtani/giturl'
+  spec.homepage      = 'https://github.com/shinyaohtani/giturl/blob/master/README.md'
   spec.license       = 'MIT'
   spec.summary       = 'Show or open GitHub URL for your local directory'
   spec.description   = <<~DESCRIPTION

--- a/lib/command_giturl.rb
+++ b/lib/command_giturl.rb
@@ -40,6 +40,7 @@ module Giturl
     end
 
     def run
+      ARGV << '.' if ARGV.empty?
       ARGV.each do |arg|
         if Giturl.git_managed?(arg)
           url = Giturl.convert(arg)

--- a/spec/giturl/command_giturl_spec.rb
+++ b/spec/giturl/command_giturl_spec.rb
@@ -60,6 +60,18 @@ RSpec.describe Giturl::CommandGiturl do
         lib_dir = "#{general_work}/#{test_name}/giturl/lib"
         expect(`bundle exec giturl #{top_dir} #{lib_dir}`.chomp).to eq "#{top_url}\n#{lib_url}"
       end
+
+      it 'outputs github URL for current directory' do
+        lib_url = repo_url + 'tree/test/%233_SampleRepo/%22-%27_%21-%3C%3E%28%29/lib/'
+        lib_dir = "#{general_work}/#{test_name}/giturl/lib"
+        expect(`bundle exec \'(cd #{lib_dir} > /dev/null && giturl .)\'`.chomp).to eq lib_url
+      end
+
+      it 'outputs github URL for current directory without being specified dirs' do
+        lib_url = repo_url + 'tree/test/%233_SampleRepo/%22-%27_%21-%3C%3E%28%29/lib/'
+        lib_dir = "#{general_work}/#{test_name}/giturl/lib"
+        expect(`bundle exec \'(cd #{lib_dir} > /dev/null && giturl)\'`.chomp).to eq lib_url
+      end
     end
   end
 end


### PR DESCRIPTION
Issue #8 

- Appended below at before the loop for each ARGV directory after parsing options.
  ```ruby
  ARGV << '.' if ARGV.empty?
  ```
- Described a spec for this feature.

