### PR TITLE
Feature/#2 support windows linux

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,12 @@ Layout/LineLength:
   AutoCorrect: false
   Max: 120
 
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
 Metrics/BlockLength:
   Enabled: true
   Max: 30

--- a/giturl.gemspec
+++ b/giturl.gemspec
@@ -33,6 +33,8 @@ Gem::Specification.new do |spec|
   spec.executables   = ['giturl']
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'launchy', '>= 2.5.0'
+
   spec.add_development_dependency 'bundler', '~> 2.0'
   spec.add_development_dependency 'github_changelog_generator', '>= 1.15.0'
   spec.add_development_dependency 'pry', '>= 0.12.2'

--- a/lib/command_giturl.rb
+++ b/lib/command_giturl.rb
@@ -5,6 +5,7 @@
 module Giturl
   require 'optparse'
   require 'giturl'
+  require 'launchy'
 
   # command line wrapper
   class CommandGiturl
@@ -25,11 +26,7 @@ module Giturl
         if Giturl.git_managed?(arg)
           url = Giturl.convert(arg)
           print "#{url}\n"
-          if @params[:open]
-            comm = +"open #{url}"
-            comm << " -a #{@params[:app]}" if @params[:app]
-            system(comm)
-          end
+          browser_open(url) if @params[:open]
         elsif @params[:verbose]
           print "Not git-managed-dir:  #{arg}\n"
         end
@@ -64,6 +61,16 @@ module Giturl
          [options]:
       BANNER
       opts
+    end
+
+    def browser_open(url)
+      if @params[:app] && Launchy::Detect::HostOsFamily.detect.darwin?
+        comm = +"open #{url}"
+        comm << " -a #{@params[:app]}" if @params[:app]
+        system(comm)
+      else
+        Launchy.open(url)
+      end
     end
   end
 end


### PR DESCRIPTION
# Support for Windows and Linux using Launchy
- Issue #2 
  - Launchy is used for launching browsers.
    - Launchy is used on OS other than macOS and on macOS when no browser is specified.
    - In other words, `system ('open')` is only called directly on macOS and when browser is specified. Even if it is macOS, Launchy will launch the browser if there is no browser specification.
      - Not macOS ==> `Launchy.open(url)`
      - macOS without `--app` ==> `Launchy.open(url)`
      - macOS with `--app` ==> `system('open -a ... url')`
   - **Since Launchy module does not support browser specification at all, on macOS and when specifying `--app`, I decided to use`system ('open')` directly instead of `Launchy.open()`.